### PR TITLE
Update documentation template

### DIFF
--- a/build/automation/lib/project/template/README.md
+++ b/build/automation/lib/project/template/README.md
@@ -66,9 +66,13 @@ Clone the repository
     git clone [project-url]
     cd ./[project-dir]
 
-The following is equivalent to the `curl -L bit.ly/make-devops-macos-setup | bash` command
+The following is equivalent to the `curl -L bit.ly/make-devops-macos-setup | bash` command. If that step has already been done it can be omitted at this point
 
     make macos-setup
+
+There are essential configuration options that **must** be set before proceeding any further. As a minimum the following command will ensure that tooling like `docker` and `git` are going to operate as expected, including local secret scanning and code formatting are enabled
+
+    make project-config
 
 Please, ask one of your colleagues for the AWS account numbers used by the project. The next command will prompt you to provide them. This information can be sourced from a properly set up project by running `make show-configuration | grep ^AWS_ACCOUNT_ID_`
 


### PR DESCRIPTION
While creating a new project from the Make DevOps template, it is unclear what needs to be done for the githooks to be put in place. For a fully set up project that would occur when the `make build` target runs. Therefore, this PR is to explicitly mention that `make project-config` must be executed as one of the first steps in the Quick Start section.