### PR TITLE
Fix terraform variable export

### DIFF
--- a/build/automation/lib/terraform.mk
+++ b/build/automation/lib/terraform.mk
@@ -120,14 +120,14 @@ terraform-export-variables-from-shell: ### Convert environment variables as TF_V
 		for str in $$(env | grep -Ei "$(PATTERN)" | sed -e 's/[[:space:]]*$$//' | grep -Ev '^[A-Za-z0-9_]+=$$' | sort | grep -Ev "$$exclude"); do
 			key=$$(cut -d "=" -f1 <<<"$$str" | tr '[:upper:]' '[:lower:]')
 			value=$$(cut -d "=" -f2- <<<"$$str")
-			echo "export TF_VAR_$${key}='$$(echo $${value} | sed -e 's/[[:space:]]/_/g')'"
+			echo "export TF_VAR_$${key}='$$(echo $${value} | sed -e 's/[[:space:]]/_/g' | sed 's/"//g' | sed "s/'//g")'"
 		done
 	fi
 	if [ -n "$(VARS)" ]; then
 		for str in $$(echo "$(VARS)" | sed 's/,/\n/g' | sort); do
 			key=$$(echo "$$str" | tr '[:upper:]' '[:lower:]')
 			value=$$(cut -d "=" -f2- <<<"$$str")
-			echo "export TF_VAR_$${key}='$$(echo $${value} | sed -e 's/[[:space:]]/_/g')'"
+			echo "export TF_VAR_$${key}='$$(echo $${value} | sed -e 's/[[:space:]]/_/g' | sed 's/"//g' | sed "s/'//g")'"
 		done
 	fi
 	IFS=$$OLDIFS


### PR DESCRIPTION
When a commit message contains a double or a single quote the terraform variable export from shell target fails to run, e.g.

Last commit message `Add health checks to the accepted paths that don't require authentication`
Error:
```
╰─ make plan PROFILE=dev
make terraform-plan STACK=elasticsearch,authentication,roles PROFILE=dev
make _terraform-stacks \
	STACKS="elasticsearch,authentication,roles" \
	CMD="plan "
# set up
eval "$(make aws-assume-role-export-variables)"
eval "$(make terraform-export-variables)"
# run stacks
for stack in $(echo elasticsearch,authentication,roles | tr "," "\n"); do
make _terraform-stack STACK="$stack" CMD="plan "
done
/bin/bash: eval: line 73: unexpected EOF while looking for matching `''
make[2]: *** [/Users/dast7/projects/nhsd-exeter/dos-service-fuzzy-search-api/build/automation/lib/terraform.mk:146: _terraform-stacks] Error 2
make[1]: *** [/Users/dast7/projects/nhsd-exeter/dos-service-fuzzy-search-api/build/automation/lib/terraform.mk:60: terraform-plan] Error 2
make: *** [Makefile:76: plan] Error 2
```
Before this fix:
```
╰─ make terraform-export-variables-from-shell PATTERN="^BUILD_COMMIT_MESSAGE"
export TF_VAR_build_commit_message='Add_health_checks_to_the_accepted_paths_that_don't_require_authentication'
```

After this fix:
```
╰─ make terraform-export-variables-from-shell PATTERN="^BUILD_COMMIT_MESSAGE"
export TF_VAR_build_commit_message='Add_health_checks_to_the_accepted_paths_that_dont_require_authentication'
```