### PR TITLE
Refactor Python installation and configuration on macOS

### DIFF
--- a/build/automation/init.mk
+++ b/build/automation/init.mk
@@ -618,7 +618,7 @@ PROFILE := $(or $(PROFILE), local)
 ENVIRONMENT := $(or $(ENVIRONMENT), $(or $(shell ([ $(PROFILE) = local ] && echo local) || (echo $(BUILD_BRANCH) | grep -Eoq '$(GIT_BRANCH_PATTERN_SUFFIX)' && (echo $(BUILD_BRANCH) | grep -Eo '[A-Za-z]{2,5}-[0-9]{1,5}' | tr '[:upper:]' '[:lower:]') || (echo $(BUILD_BRANCH) | grep -Eoq '^tags/$(GIT_TAG_PATTERN)' && echo $(PROFILE)) || ([ $(BUILD_BRANCH) = master ] && echo $(PROFILE)))), unknown))
 
 PATH_HOMEBREW := /opt/homebrew/opt/coreutils/libexec/gnubin:/opt/homebrew/opt/findutils/libexec/gnubin:/opt/homebrew/opt/grep/libexec/gnubin:/opt/homebrew/opt/gnu-sed/libexec/gnubin:/opt/homebrew/opt/gnu-tar/libexec/gnubin:/opt/homebrew/opt/make/libexec/gnubin:/opt/homebrew/bin:/usr/local/opt/coreutils/libexec/gnubin:/usr/local/opt/findutils/libexec/gnubin:/usr/local/opt/grep/libexec/gnubin:/usr/local/opt/gnu-sed/libexec/gnubin:/usr/local/opt/gnu-tar/libexec/gnubin:/usr/local/opt/make/libexec/gnubin
-PATH_DEVOPS := $(BIN_DIR)
+PATH_DEVOPS := $(BIN_DIR):$(HOME)/.pyenv/bin:$(HOME)/.pyenv/shims
 PATH_SYSTEM := /usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin
 
 # ==============================================================================

--- a/build/automation/lib/python.mk
+++ b/build/automation/lib/python.mk
@@ -20,18 +20,16 @@ PYTHON_BASE_PACKAGES = \
 	requests==2.25.1
 
 python-install: ### Install and configure Python - optional: PYTHON_VERSION
-	brew unlink python@$(PYTHON_VERSION_MAJOR).$(PYTHON_VERSION_MINOR); brew link --overwrite --force python@$(PYTHON_VERSION_MAJOR).$(PYTHON_VERSION_MINOR)
-	rm -f $$(brew --prefix)/bin/python
-	ln $$(brew --prefix)/bin/python3 $$(brew --prefix)/bin/python
+	if [ $(SYSTEM_DIST) == macos ]; then
+		brew unlink python@$(PYTHON_VERSION_MAJOR).$(PYTHON_VERSION_MINOR); brew link --overwrite --force python@$(PYTHON_VERSION_MAJOR).$(PYTHON_VERSION_MINOR)
+		rm -f $$(brew --prefix)/bin/python
+		ln $$(brew --prefix)/bin/python3 $$(brew --prefix)/bin/python
+	fi
 	[ -d $$HOME/.pyenv/.git ] && ( cd $$HOME/.pyenv; git pull ) || ( rm -rf $$HOME/.pyenv; git clone https://github.com/pyenv/pyenv.git $$HOME/.pyenv )
-	(
-		export PATH="$$HOME/.pyenv/bin:$(PATH_SYSTEM):$$(brew --prefix)/bin"
-		pyenv install --skip-existing $(PYTHON_VERSION)
-		export PATH="$$HOME/.pyenv/bin:$(PATH)"
-		python3 -m pip install --upgrade pip
-		pip install $(PYTHON_BASE_PACKAGES)
-		pyenv global $(PYTHON_VERSION)
-	)
+	pyenv install --skip-existing $(PYTHON_VERSION)
+	python -m pip install --upgrade pip
+	pip install $(PYTHON_BASE_PACKAGES)
+	pyenv global $(PYTHON_VERSION)
 
 python-virtualenv: ### Setup Python virtual environment - optional: PYTHON_VERSION,PYTHON_VENV_NAME
 	pyenv install --skip-existing $(PYTHON_VERSION)
@@ -39,19 +37,19 @@ python-virtualenv: ### Setup Python virtual environment - optional: PYTHON_VERSI
 		pyenv local $(PYTHON_VERSION)
 		pip install --upgrade pip
 		pip install $(PYTHON_BASE_PACKAGES)
-		sed -i 's;    "python.linting.flake8Path":.*;    "python.linting.flake8Path": "~/.pyenv/versions/$(PYTHON_VERSION)/bin/flake8",;g' project.code-workspace
-		sed -i 's;    "python.linting.mypyPath":.*;    "python.linting.mypyPath": "~/.pyenv/versions/$(PYTHON_VERSION)/bin/mypy",;g' project.code-workspace
-		sed -i 's;    "python.linting.pylintPath":.*;    "python.linting.pylintPath": "~/.pyenv/versions/$(PYTHON_VERSION)/bin/pylint",;g' project.code-workspace
-		sed -i 's;    "python.pythonPath":.*;    "python.pythonPath": "~/.pyenv/versions/$(PYTHON_VERSION)/bin/python",;g' project.code-workspace
+		sed -i 's;    "python.linting.flake8Path":.*;    "python.linting.flake8Path": "~/.pyenv/versions/$(PYTHON_VERSION)/bin/flake8",;g' project.code-workspace 2> /dev/null ||:
+		sed -i 's;    "python.linting.mypyPath":.*;    "python.linting.mypyPath": "~/.pyenv/versions/$(PYTHON_VERSION)/bin/mypy",;g' project.code-workspace 2> /dev/null ||:
+		sed -i 's;    "python.linting.pylintPath":.*;    "python.linting.pylintPath": "~/.pyenv/versions/$(PYTHON_VERSION)/bin/pylint",;g' project.code-workspace 2> /dev/null ||:
+		sed -i 's;    "python.pythonPath":.*;    "python.pythonPath": "~/.pyenv/versions/$(PYTHON_VERSION)/bin/python",;g' project.code-workspace 2> /dev/null ||:
 	else
 		pyenv virtualenv $(PYTHON_VERSION) $(PYTHON_VENV_NAME)
 		pyenv local $(PYTHON_VENV_NAME)
 		pip install --upgrade pip
 		pip install $(PYTHON_BASE_PACKAGES)
-		sed -i 's;    "python.linting.flake8Path":.*;    "python.linting.flake8Path": "~/.pyenv/versions/$(PYTHON_VENV_NAME)/bin/flake8",;g' project.code-workspace
-		sed -i 's;    "python.linting.mypyPath":.*;    "python.linting.mypyPath": "~/.pyenv/versions/$(PYTHON_VENV_NAME)/bin/mypy",;g' project.code-workspace
-		sed -i 's;    "python.linting.pylintPath":.*;    "python.linting.pylintPath": "~/.pyenv/versions/$(PYTHON_VENV_NAME)/bin/pylint",;g' project.code-workspace
-		sed -i 's;    "python.pythonPath":.*;    "python.pythonPath": "~/.pyenv/versions/$(PYTHON_VENV_NAME)/bin/python",;g' project.code-workspace
+		sed -i 's;    "python.linting.flake8Path":.*;    "python.linting.flake8Path": "~/.pyenv/versions/$(PYTHON_VENV_NAME)/bin/flake8",;g' project.code-workspace 2> /dev/null ||:
+		sed -i 's;    "python.linting.mypyPath":.*;    "python.linting.mypyPath": "~/.pyenv/versions/$(PYTHON_VENV_NAME)/bin/mypy",;g' project.code-workspace 2> /dev/null ||:
+		sed -i 's;    "python.linting.pylintPath":.*;    "python.linting.pylintPath": "~/.pyenv/versions/$(PYTHON_VENV_NAME)/bin/pylint",;g' project.code-workspace 2> /dev/null ||:
+		sed -i 's;    "python.pythonPath":.*;    "python.pythonPath": "~/.pyenv/versions/$(PYTHON_VENV_NAME)/bin/python",;g' project.code-workspace 2> /dev/null ||:
 	fi
 
 python-virtualenv-clean: ### Clean up Python virtual environment - optional: PYTHON_VERSION=[version or venv name]


### PR DESCRIPTION
This change includes the following:
- Use python version installed by `pyenv` rather than the Homebrew preferred one by modifying `$PATH` variable
- Configure python via Homebrew only if on macOS
- Silent errors while changing python version in a project workspace on a non-existing file (very seldom but can happen)

A way to test it would be:
1. Clone the repository
2. Run `make python-virtualenv` then `reload; python --version` which should give `3.9.5`