### PR TITLE
Add ECR Image Scanning reports make targets

### DIFF
--- a/build/automation/lib/aws.mk
+++ b/build/automation/lib/aws.mk
@@ -308,6 +308,7 @@ aws-ecr-create-repository: ### Create ECR repository to store an image - mandato
 	make -s docker-run-tools ARGS="$$(echo $(AWSCLI) | grep awslocal > /dev/null 2>&1 && echo '--env LOCALSTACK_HOST=$(LOCALSTACK_HOST)' ||:)" CMD=" \
 		$(AWSCLI) ecr create-repository \
 			--repository-name $(PROJECT_GROUP_SHORT)/$(PROJECT_NAME_SHORT)/$(NAME) \
+			--image-scanning-configuration scanOnPush=true \
 			--tags Key=Programme,Value=$(PROGRAMME) Key=Service,Value=$(SERVICE_TAG) \
 	"
 	make -s docker-run-tools ARGS="$$(echo $(AWSCLI) | grep awslocal > /dev/null 2>&1 && echo '--env LOCALSTACK_HOST=$(LOCALSTACK_HOST)' ||:)" CMD=" \

--- a/build/automation/lib/aws.mk
+++ b/build/automation/lib/aws.mk
@@ -324,6 +324,54 @@ aws-ecr-get-image-digest: ### Get ECR image digest by matching tag pattern - man
 			--repository-name $(shell echo $(REPO) | sed "s;$(AWS_ECR)/;;g") \
 	" | make -s docker-run-tools CMD="jq -rf $$file" | head -n 1
 
+aws-ecr-get-security-scan: ### Fetches container scan report and returns findings - Mandatory REPOSITORY, TAG=[image tag], UNACCEPTABLE_VULNERABILITY_LEVELS=[LOW,MEDIUM,HIGH,CRITICAL]; optional: FAIL_ON_WARNINGS=true, SHOW_ALL_WARNINGS=true
+	make -s aws-ecr-wait-for-image-scan-complete REPOSITORY=$(REPOSITORY) TAG=$(TAG)
+	SCAN_FINDINGS=$$(make -s aws-ecr-describe-image-scan-findings REPOSITORY=$(REPOSITORY) TAG=$(TAG))
+	SCAN_WARNINGS=$$(echo $$SCAN_FINDINGS | jq '.imageScanFindings.findingSeverityCounts')
+	CRITICAL=$$(echo $$SCAN_WARNINGS | jq '.CRITICAL')
+	HIGH=$$(echo $$SCAN_WARNINGS | jq '.HIGH')
+	MEDIUM=$$(echo $$SCAN_WARNINGS | jq '.MEDIUM')
+	LOW=$$(echo $$SCAN_WARNINGS | jq '.LOW')
+	INFORMATIONAL=$$(echo $$SCAN_WARNINGS | jq '.INFORMATIONAL')
+	UNDEFINED=$$(echo $$SCAN_WARNINGS | jq '.UNDEFINED')
+	if [[ "$(SHOW_ALL_WARNINGS)" =~ ^(true|yes|y|on|1|TRUE|YES|Y|ON)$$ ]]; then
+		echo "CRITICAL: $$CRITICAL"
+		echo "HIGH: $$HIGH"
+		echo "MEDIUM: $$MEDIUM"
+		echo "LOW: $$LOW"
+		echo "INFORMATIONAL: $$INFORMATIONAL"
+		echo "UNDEFINED: $$UNDEFINED"
+	fi
+	IS_UNACCEPTABLE_WARNINGS=false
+	for LEVEL in $$(echo $(UNACCEPTABLE_VULNERABILITY_LEVELS) | tr "," "\n" | tr [:lower:] [:upper:]); do
+		if [ "$$(echo $$(eval echo \"\$$$$LEVEL\"))" != null ]; then
+			echo $$LEVEL is above the threshold
+			IS_UNACCEPTABLE_WARNINGS=true
+		fi
+	done
+	echo "For more details visit https://$(AWS_REGION).console.aws.amazon.com/ecr/repositories/private/$(AWS_ACCOUNT_ID_MGMT)/$(PROJECT_GROUP_SHORT)/$(PROJECT_NAME_SHORT)/$(REPOSITORY)?region=$(AWS_REGION)"
+	if [[ "$(FAIL_ON_WARNINGS)" =~ ^(true|yes|y|on|1|TRUE|YES|Y|ON)$$ ]] && [ $$IS_UNACCEPTABLE_WARNINGS == "true" ]; then
+		exit 1
+	fi
+
+aws-ecr-wait-for-image-scan-complete: ### Waits for ECR image scan report - REPOSITORY, TAG=[image tag]
+	make -s docker-run-tools ARGS="$$(echo $(AWSCLI) | grep awslocal > /dev/null 2>&1 && echo '--env LOCALSTACK_HOST=$(LOCALSTACK_HOST)' ||:)" CMD=" \
+			$(AWSCLI) ecr wait image-scan-complete \
+			--registry-id $(AWS_ACCOUNT_ID_MGMT) \
+			--repository-name $(PROJECT_GROUP_SHORT)/$(PROJECT_NAME_SHORT)/$(REPOSITORY) \
+			--image-id imageTag=$(TAG) \
+			--output json \
+		"
+
+aws-ecr-describe-image-scan-findings: ### Describes ECR image scan report - REPOSITORY, TAG=[image tag]
+		make -s docker-run-tools ARGS="$$(echo $(AWSCLI) | grep awslocal > /dev/null 2>&1 && echo '--env LOCALSTACK_HOST=$(LOCALSTACK_HOST)' ||:)" CMD=" \
+			$(AWSCLI) ecr describe-image-scan-findings \
+			--registry-id $(AWS_ACCOUNT_ID_MGMT) \
+			--repository-name $(PROJECT_GROUP_SHORT)/$(PROJECT_NAME_SHORT)/$(REPOSITORY) \
+			--image-id imageTag=$(TAG) \
+			--output json \
+		"
+
 aws-ses-verify-email-identity: ### Verify SES email address - mandatory: NAME
 	make -s docker-run-tools ARGS="$$(echo $(AWSCLI) | grep awslocal > /dev/null 2>&1 && echo '--env LOCALSTACK_HOST=$(LOCALSTACK_HOST)' ||:)" CMD=" \
 		$(AWSCLI) ses verify-email-identity \
@@ -513,6 +561,9 @@ aws-accounts-create-template-config-file-v1: ### Create AWS accounts variables t
 	aws-dynamodb-query \
 	aws-ecr-get-image-digest \
 	aws-ecr-get-login-password \
+	aws-ecr-get-security-scan \
+	aws-ecr-wait-for-image-scan-complete \
+	aws-ecr-describe-image-scan-findings \
 	aws-elasticsearch-get-endpoint \
 	aws-iam-policy-exists \
 	aws-iam-role-exists \


### PR DESCRIPTION
This PR is to add some make targets to facilitate ECR image scanning so that reports can be scanned and output to a Pipeline. With the correct input this can also block a pipeline so that docker images with warnings aren't deployed.

This PR is in draft as it still in testing in the DI Pipelines