### PR TITLE
DLS-317 Add make target opt to allow empty file replace variable

### DIFF
--- a/build/automation/lib/file.mk
+++ b/build/automation/lib/file.mk
@@ -26,12 +26,12 @@ file-replace-variables: ### Replace all placholders in given file - mandatory: F
 			echo "WARNING: Variable $$key has no value in '$$(echo $(FILE) | sed "s;$(PROJECT_DIR);;g")'"
 		fi
 		if [ ! -z "$$value" ] || [[ "$(REPLACE_NO_VALUE)" =~ ^(true|yes|y|on|1|TRUE|YES|Y|ON)$$ ]]; then
-		# Replace `${VARIABLE_TO_REPLACE}`
-		sed -i "s;\$${$${key}$${suffix}};$${value//&/\\&};g" $(FILE)
-		# Replace `$VARIABLE_TO_REPLACE`
-		sed -i "s;\$$$${key}$${suffix};$${value//&/\\&};g" $(FILE)
-		# Replace `VARIABLE_TO_REPLACE`
-		sed -i "s;$${key}$${suffix};$${value//&/\\&};g" $(FILE)
+			# Replace `${VARIABLE_TO_REPLACE}`
+			sed -i "s;\$${$${key}$${suffix}};$${value//&/\\&};g" $(FILE)
+			# Replace `$VARIABLE_TO_REPLACE`
+			sed -i "s;\$$$${key}$${suffix};$${value//&/\\&};g" $(FILE)
+			# Replace `VARIABLE_TO_REPLACE`
+			sed -i "s;$${key}$${suffix};$${value//&/\\&};g" $(FILE)
 		fi
 	done
 	# Replace placholders in file name

--- a/build/automation/lib/file.mk
+++ b/build/automation/lib/file.mk
@@ -15,7 +15,7 @@ file-replace-content: ### Replace multiline content from given file - mandatory:
 	mv -f $$tmp_file $(FILE)
 	chmod $$permissions $(FILE)
 
-file-replace-variables: ### Replace all placholders in given file - mandatory: FILE; optional: SUFFIX=[variable suffix, defaults to _TO_REPLACE],EXCLUDE_FILE_NAME=true
+file-replace-variables: ### Replace all placholders in given file - mandatory: FILE; optional: SUFFIX=[variable suffix, defaults to _TO_REPLACE],EXCLUDE_FILE_NAME=true,REPLACE_NO_VALUE=true
 	suffix=$(or $(SUFFIX), _TO_REPLACE)
 	echo "Replace placholders in '$$(echo $(FILE) | sed "s;$(PROJECT_DIR);;g")'"
 	# Replace placholders in file content
@@ -24,13 +24,14 @@ file-replace-variables: ### Replace all placholders in given file - mandatory: F
 		value=$$(echo $$(eval echo "\$$$$key"))
 		if [ -z "$$value" ]; then
 			echo "WARNING: Variable $$key has no value in '$$(echo $(FILE) | sed "s;$(PROJECT_DIR);;g")'"
-		else
-			# Replace `${VARIABLE_TO_REPLACE}`
-			sed -i "s;\$${$${key}$${suffix}};$${value//&/\\&};g" $(FILE)
-			# Replace `$VARIABLE_TO_REPLACE`
-			sed -i "s;\$$$${key}$${suffix};$${value//&/\\&};g" $(FILE)
-			# Replace `VARIABLE_TO_REPLACE`
-			sed -i "s;$${key}$${suffix};$${value//&/\\&};g" $(FILE)
+		fi
+		if [ ! -z "$$value" ] || [[ "$(REPLACE_NO_VALUE)" =~ ^(true|yes|y|on|1|TRUE|YES|Y|ON)$$ ]]; then
+		# Replace `${VARIABLE_TO_REPLACE}`
+		sed -i "s;\$${$${key}$${suffix}};$${value//&/\\&};g" $(FILE)
+		# Replace `$VARIABLE_TO_REPLACE`
+		sed -i "s;\$$$${key}$${suffix};$${value//&/\\&};g" $(FILE)
+		# Replace `VARIABLE_TO_REPLACE`
+		sed -i "s;$${key}$${suffix};$${value//&/\\&};g" $(FILE)
 		fi
 	done
 	# Replace placholders in file name
@@ -42,10 +43,12 @@ file-replace-variables: ### Replace all placholders in given file - mandatory: F
 			file=$$(echo $$file | sed "s;$${key}$${suffix};$${value};g")
 		done
 		echo "Rename file '$$(echo $(FILE) | sed "s;$(PROJECT_DIR);;g")' to '$$file'"
-		[ -z "$$value" ] && echo "WARNING: Variable $$key has no value for '$(FILE)'" || ( \
+		[ -z "$$value" ] && echo "WARNING: Variable $$key has no value for '$(FILE)'"
+
+		if [ ! -z "$$value" ] || [[ "$(REPLACE_NO_VALUE)" =~ ^(true|yes|y|on|1|TRUE|YES|Y|ON)$$ ]]; then
 			mkdir -p $$(dirname $$file)
 			mv -f $(FILE) $$file
-		)
+		fi
 	fi
 
 file-replace-variables-in-dir: ### Replace placholders in all files in given directory - mandatory: DIR; optional: SUFFIX=[variable suffix, defaults to _TO_REPLACE],EXCLUDE_FILE_NAME=true

--- a/build/automation/test/file.test.mk
+++ b/build/automation/test/file.test.mk
@@ -11,6 +11,7 @@ test-file:
 		test-file-replace-variables-file-name \
 		test-file-replace-variables-file-name-exclude-file-name \
 		test-file-replace-variables-in-dir \
+		test-file-replace-variables-replace-no-value \
 		test-file-copy-and-replace \
 	)
 	for test in $${tests[*]}; do
@@ -109,6 +110,17 @@ test-file-replace-variables-file-name-exclude-file-name:
 
 test-file-replace-variables-in-dir:
 	mk_test_skip
+
+test-file-replace-variables-replace-no-value:
+	# arrange
+	echo test: VARIABLE_TO_REPLACE > $(TEST_FILE)
+	# act
+	export VARIABLE=
+	make file-replace-variables FILE=$(TEST_FILE) REPLACE_NO_VALUE=true
+	# assert
+	mk_test "test: = $$(cat $(TEST_FILE))"
+	# clean up
+	rm -f $(TEST_FILE)
 
 test-file-copy-and-replace:
 	# arrange


### PR DESCRIPTION
Made a change to the file-replace-variable target to provide an option REPLACE_NO_VALUE which when set to true will replace _TO_REPLACE variables even if the set value has no value.

Found this was need when working on a change for DoS Live Service (https://nhsd-jira.digital.nhs.uk/browse/DLS-317)
